### PR TITLE
fix: update runner from ubuntu-20.04 to ubuntu-24.04

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     if: github.repository == 'etclabscore/discv4-dns-lists'
     name: Discv4-DNS-Crawler
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       ETH_DNS_DISCV4_CRAWLTIME: 30m
       ETH_DNS_DISCV4_PARENT_DOMAIN: blockd.info


### PR DESCRIPTION
Updates GitHub Actions runner to ubuntu-24.04 (latest LTS).

Ref: https://github.com/actions/runner-images/issues/11101