### PR TITLE
fix: update workflow actions and use GITHUB_TOKEN

### DIFF
--- a/.ci/crawl.sh
+++ b/.ci/crawl.sh
@@ -5,7 +5,7 @@ devp2p discv4 crawl -timeout "$ETH_DNS_DISCV4_CRAWLTIME" all.json
 git add all.json
 
 ETH_DNS_DISCV4_KEY_PUBLICINFO="$(cat $ETH_DNS_DISCV4_KEYPASS_PATH | ethkey inspect $ETH_DNS_DISCV4_KEY_PATH | grep -E '(Addr|Pub)')"
-git -c user.name="ziogaschr" -c user.email='ziogaschr@gmail.com' commit --author 'crawler <>' -m "ci update (all.json) $GITHUB_RUN_ID:$GITHUB_RUN_NUMBER
+git -c user.name='github-actions[bot]' -c user.email='github-actions[bot]@users.noreply.github.com' commit --author 'crawler <>' -m "ci update (all.json) $GITHUB_RUN_ID:$GITHUB_RUN_NUMBER
 
 Crawltime: $ETH_DNS_DISCV4_CRAWLTIME
 

--- a/.ci/filter_and_sign.sh
+++ b/.ci/filter_and_sign.sh
@@ -58,7 +58,7 @@ for network in "$@"; do
     done
 
     ETH_DNS_DISCV4_KEY_PUBLICINFO="$(cat $ETH_DNS_DISCV4_KEYPASS_PATH | ethkey inspect $ETH_DNS_DISCV4_KEY_PATH | grep -E '(Addr|Pub)')"
-    git -c user.name="ziogaschr" -c user.email='ziogaschr@gmail.com' commit --author "crawler <>" -m "ci update ($network) $GITHUB_RUN_ID:$GITHUB_RUN_NUMBER
+    git -c user.name='github-actions[bot]' -c user.email='github-actions[bot]@users.noreply.github.com' commit --author 'crawler <>' -m "ci update ($network) $GITHUB_RUN_ID:$GITHUB_RUN_NUMBER
         
 Crawltime: $ETH_DNS_DISCV4_CRAWLTIME
 

--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -11,6 +11,8 @@ jobs:
     if: github.repository == 'etclabscore/discv4-dns-lists'
     name: Discv4-DNS-Crawler
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     env:
       ETH_DNS_DISCV4_CRAWLTIME: 30m
       ETH_DNS_DISCV4_PARENT_DOMAIN: blockd.info
@@ -36,7 +38,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: etccore
-        token: ${{ secrets.PAT_REPO }}
 
     - name: Checkout submodules
       shell: bash
@@ -91,12 +92,9 @@ jobs:
         ./.ci/deploy.sh classic mordor
 
     - name: Push
-      env:
-        GITHUB_PAT: ${{ secrets.PAT_REPO }}
       run: |
-        git config --local user.name 'ziogaschr'
-        git config --local user.email 'ziogaschr@gmail.com'
-        git remote set-url origin https://ziogaschr:${GITHUB_PAT}@github.com/${GITHUB_REPOSITORY}.git
+        git config --local user.name 'github-actions[bot]'
+        git config --local user.email 'github-actions[bot]@users.noreply.github.com'
         git push origin etccore
 
     - uses: actions/checkout@v4

--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -57,7 +57,7 @@ jobs:
         make all
         echo "$(pwd)/build/bin" >> $GITHUB_PATH
         cd ..
-        git diff --quiet || { git add core-geth && git -c user.name='ziogaschr' -c user.email='ziogaschr@gmail.com' commit --author='crawler <>' -m "ci update (core-geth:${checkout_ref}) $GITHUB_RUN_ID:$GITHUB_RUN_NUMBER"; }
+        git diff --quiet || { git add core-geth && git -c user.name='github-actions[bot]' -c user.email='github-actions[bot]@users.noreply.github.com' commit --author='crawler <>' -m "ci update (core-geth:${checkout_ref}) $GITHUB_RUN_ID:$GITHUB_RUN_NUMBER"; }
 
     - name: Setup secrets
       run: |

--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -38,10 +38,6 @@ jobs:
         ref: etccore
         token: ${{ secrets.PAT_REPO }}
 
-    - uses: actions/checkout@v2
-      with:
-        ref: etccore
-        token: ${{ secrets.PAT_REPO }}
     - name: Checkout submodules
       shell: bash
       run: |

--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -33,7 +33,7 @@ jobs:
     - run: sudo apt-get install -y jq
 
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: etccore
         token: ${{ secrets.PAT_REPO }}
@@ -99,7 +99,7 @@ jobs:
         git remote set-url origin https://ziogaschr:${GITHUB_PAT}@github.com/${GITHUB_REPOSITORY}.git
         git push origin etccore
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: HandleIfFailure
       if: failure()
       uses: JasonEtco/create-an-issue@v2

--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: 1.22.4
       id: go


### PR DESCRIPTION
## Summary
- Remove duplicate checkout step
- Update actions/checkout from v2 to v4
- Update actions/setup-go from v2 to v5
- Replace PAT_REPO with GITHUB_TOKEN to avoid token expiration issues

## Test plan
- [ ] Run workflow manually to verify it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)